### PR TITLE
Adds a `Workplace.RemoveWorkers()` call to `Workplace.SetWorkers(0)`

### DIFF
--- a/Automation/ScriptingEngine/ScriptableComponents/Components/WorkplaceScriptableComponent.cs
+++ b/Automation/ScriptingEngine/ScriptableComponents/Components/WorkplaceScriptableComponent.cs
@@ -85,6 +85,10 @@ sealed class WorkplaceScriptableComponent : ScriptableComponentBase {
   static void SetWorkersAction(Workplace building, ScriptValue[] args) {
     AssertActionArgsCount(SetWorkersActionName, args, 1);
     var numWorkers = args[0].AsInt;
+    if (numWorkers == 0) {
+      ResetWorkersAction(building);
+      return;
+    }
     if (numWorkers < 1 || numWorkers > building.MaxWorkers) {
       throw new ScriptError.ValueOutOfRange($"Number of workers out of range: {numWorkers}");
     }


### PR DESCRIPTION
Adds a `Workplace.RemoveWorkers()` call to `Workplace.SetWorkers(0)` , so we don't have to rewrite `Workplace.SetWorkers(1)` to `Workplace.RemoveWorkers()`, allowing us to no longer need to invert the rule, to get the correct call to set the amount of workers to 0.